### PR TITLE
Fix error handling on failed responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool]
 [tool.poetry]
 name = "apns2"
-version = "0.7.3"
+version = "0.7.4"
 description = "A python library for interacting with the Apple Push Notification Service via HTTP/2 protocol"
 readme = 'README.md'
 authors = [


### PR DESCRIPTION
- Errors are returned as a dictionary in the response. The code was passing that along as a string instead of deserializing it to gather the actual failure reason. This would result in exceptions throwing KeyError instead of the actual exception class